### PR TITLE
#8 -8 중복 회원 가입 체크시 로직 개선

### DIFF
--- a/src/main/java/com/server/oceankeeper/Domain/User/UserRepository.java
+++ b/src/main/java/com/server/oceankeeper/Domain/User/UserRepository.java
@@ -16,4 +16,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     public Optional<User> findByDeviceToken(String deviceToken);
 
+    boolean existsByProviderAndProviderId(String provider, String providerId);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByDeviceToken(String deviceToken);
+
 }


### PR DESCRIPTION
기존
- 중복가입 체크시 전체 user 객체를 가져오는 방식 개선 
- existsBy함수 도입하여 객체 생성할 필요없이 존재여부만 체크하는 것으로 변경함