### PR TITLE
Feature/#21 valid aop

### DIFF
--- a/src/main/java/com/server/oceankeeper/Domain/Profile/ProfileController.java
+++ b/src/main/java/com/server/oceankeeper/Domain/Profile/ProfileController.java
@@ -1,5 +1,6 @@
 package com.server.oceankeeper.Domain.Profile;
 
+import com.server.oceankeeper.Global.Exception.IllegalRequestException;
 import com.server.oceankeeper.Global.Jwt.JwtConfig;
 import com.server.oceankeeper.Global.Jwt.JwtProcess;
 
@@ -24,9 +25,13 @@ public class ProfileController {
 
 
     //썸네일 수정
-    @ApiOperation(value = "썸네일 수정 [권한 필요]", notes = "기존 프로필 이미지 s3 수정 후 저장된 url을 반환합니다.", response = ProfileDto.class)
+    @ApiOperation(value = "썸네일 수정 [권한 필요]", notes = "기존 프로필 이미지 s3 수정 후 저장된 url을 반환합니다.", response = ProfileResDto.class)
     @PutMapping("/user/profile")
-    public ResponseEntity<ProfileDto> edit(@RequestPart("profile") MultipartFile profile, HttpServletRequest request) throws IOException {
+    public ResponseEntity<ProfileResDto> edit(@RequestPart("profile") MultipartFile profile, HttpServletRequest request) throws IOException {
+
+        if(profile.isEmpty()){
+            throw new IllegalRequestException("profile 이미지가 정상적으로 전송되지 않았습니다.");
+        }
         String jwtToken = request.getHeader(JwtConfig.HEADER).replace(JwtConfig.TOKEN_PREFIX, "");
         Long id = JwtProcess.toUserId(jwtToken);
         //기존 파일 s3에서 삭제
@@ -37,19 +42,24 @@ public class ProfileController {
         //db 정보 변경하기
         profileService.updateProfile(id, url);
 
-        ProfileDto profileDto = ProfileDto.builder().url(url).build();
+        ProfileResDto profileResDto = ProfileResDto.builder().url(url).build();
 
-        return new ResponseEntity<>(profileDto, HttpStatus.OK);
+        return new ResponseEntity<>(profileResDto, HttpStatus.OK);
     }
 
-    @ApiOperation(value = "썸네일 등록 [권한 필요 없음]", notes = "프로필 이미지를 S3에 저장 후 저장된 url을 반환합니다.", response = ProfileDto.class)
+    @ApiOperation(value = "썸네일 등록 [권한 필요 없음]", notes = "프로필 이미지를 S3에 저장 후 저장된 url을 반환합니다.", response = ProfileResDto.class)
     @PostMapping(("/user/profile"))
-    public ResponseEntity<ProfileDto> uploadProfile(@RequestPart("profile") MultipartFile profile) throws IOException{
+    public ResponseEntity<ProfileResDto> uploadProfile(@RequestPart("profile") MultipartFile profile) throws IOException{
+
+        if(profile.isEmpty()){
+            throw new IllegalRequestException("profile 이미지가 정상적으로 전송되지 않았습니다.");
+        }
+
         String url = profileService.uploadNewProfile(profile, "profile");
 
-        ProfileDto profileDto = ProfileDto.builder().url(url).build();
+        ProfileResDto profileResDto = ProfileResDto.builder().url(url).build();
 
-        return ResponseEntity.ok(profileDto);
+        return ResponseEntity.ok(profileResDto);
     }
 
 

--- a/src/main/java/com/server/oceankeeper/Domain/Profile/ProfileResDto.java
+++ b/src/main/java/com/server/oceankeeper/Domain/Profile/ProfileResDto.java
@@ -4,22 +4,25 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Data;
 
+import javax.validation.constraints.NotEmpty;
+
 
 @Data
-public class ProfileDto {
+public class ProfileResDto {
 
     @ApiModelProperty(
             value = "s3 내 이미지 파일의 전체 url",
             dataType = "String",
             example = "https://oceankeeper-image.s3.ap-northeast-2.amazonaws.com/profile/cb1de9d3-b982-4b9f-a574-174b834bae2etest.png\"")
+    @NotEmpty
     private String url;
 
-    public ProfileDto() {
+    public ProfileResDto() {
 
     }
 
     @Builder
-    public ProfileDto(String fileFullPath, String url) {
+    public ProfileResDto(String fileFullPath, String url) {
         this.url = url;
     }
 }

--- a/src/main/java/com/server/oceankeeper/Domain/User/UserController.java
+++ b/src/main/java/com/server/oceankeeper/Domain/User/UserController.java
@@ -9,10 +9,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
 
 @RequiredArgsConstructor
 @RequestMapping("")
@@ -23,7 +26,7 @@ public class UserController {
     private final Logger log = LoggerFactory.getLogger(getClass()); //@slf4j 대신에 사용한다.
 
     @PostMapping("/auth/signup")
-    public ResponseEntity<JoinResDto> mehtod(@RequestBody JoinReqDto joinReqDto) {
+    public ResponseEntity<JoinResDto> join(@RequestBody @Valid JoinReqDto joinReqDto, BindingResult bindingResult) {
         log.debug("디버그 : 회원가입 컨트롤러 호출");
         JoinResDto joinResDto = userService.join(joinReqDto);
         log.debug("디버그 : 회원가입 사용자 등록 완료");

--- a/src/main/java/com/server/oceankeeper/Domain/User/dto/JoinReqDto.java
+++ b/src/main/java/com/server/oceankeeper/Domain/User/dto/JoinReqDto.java
@@ -25,7 +25,7 @@ public class JoinReqDto{
     @NotEmpty
     private final String providerId;
 
-    @Pattern(regexp = "^[a-zA-Z0-9]{2,20}$", message="영문과 숫자로만 구성된 2~20자 이내의 닉네임을 사용해주세요")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,20}$", message="한글/영문/숫자로만 구성된 2~20자 이내의 닉네임을 사용해주세요")
     @NotEmpty
     private final String nickname;
 

--- a/src/main/java/com/server/oceankeeper/Domain/User/dto/JoinReqDto.java
+++ b/src/main/java/com/server/oceankeeper/Domain/User/dto/JoinReqDto.java
@@ -7,23 +7,37 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Data;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+
 @Data
 public class JoinReqDto{
     @ApiModelProperty(
             value = "Oauth Provider",
             dataType = "String",
             example = "naver")
+    @NotEmpty
     private final String provider;
     @ApiModelProperty(
             value = "Oauth Provider Id",
             dataType = "String"
     )
+    @NotEmpty
     private final String providerId;
 
+    @Pattern(regexp = "^[a-zA-Z0-9]{2,20}$", message="영문과 숫자로만 구성된 2~20자 이내의 닉네임을 사용해주세요")
+    @NotEmpty
     private final String nickname;
+
+
+
+    @Pattern(regexp = "^[a-zA-Z0-9]{2,10}@[a-zA-Z0-9]{2,6}\\.[a-zA-Z]{2,3}$", message = "유효한 이메일 형식으로 작성해주세요")
+    @NotEmpty
     private final String email;
+    @NotEmpty
     private final String profile;
 
+    @NotEmpty
     private final String deviceToken;
 
     @Builder

--- a/src/main/java/com/server/oceankeeper/Domain/User/dto/LoginReqDto.java
+++ b/src/main/java/com/server/oceankeeper/Domain/User/dto/LoginReqDto.java
@@ -3,10 +3,14 @@ package com.server.oceankeeper.Domain.User.dto;
 import lombok.Builder;
 import lombok.Data;
 
+import javax.validation.constraints.NotEmpty;
+
 @Data
 public class LoginReqDto {
+    @NotEmpty
 
     private String providerId;
+    @NotEmpty
     private String provider;
 
     public LoginReqDto() {

--- a/src/main/java/com/server/oceankeeper/Global/AOP/DtoValidataionAdvice.java
+++ b/src/main/java/com/server/oceankeeper/Global/AOP/DtoValidataionAdvice.java
@@ -1,0 +1,47 @@
+package com.server.oceankeeper.Global.AOP;
+
+import com.server.oceankeeper.Global.Exception.DtoValidationException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.HashMap;
+import java.util.Map;
+@Component
+@Aspect
+public class DtoValidataionAdvice {
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping)")
+    public void postMapping(){}
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PutMapping)")
+    public void putMapping(){}
+
+
+    //유효성 검사 aop로 따로 빼놓았음
+    @Around("postMapping() || putMapping()")
+    public Object validationAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Object[] args = proceedingJoinPoint.getArgs(); // jointPoint의 매개변수
+        for(Object arg : args){
+
+            //valid 통과를못해서 bindingResult에 오류가 있을 경우 예외를 던진다.
+            if(arg instanceof BindingResult){
+                BindingResult bindingResult = (BindingResult) arg;
+                if(bindingResult.hasErrors()){
+                    Map<String, String> errorMap = new HashMap<>();
+
+                    for(FieldError error : bindingResult.getFieldErrors()){
+                        errorMap.put(error.getField(), error.getDefaultMessage());
+                    }
+                    throw new DtoValidationException("유효성 검사 실패", errorMap);
+                }
+            }
+        }
+        //정상적 메서드 실행
+        return proceedingJoinPoint.proceed();
+    }
+}

--- a/src/main/java/com/server/oceankeeper/Global/Exception/DtoValidationException.java
+++ b/src/main/java/com/server/oceankeeper/Global/Exception/DtoValidationException.java
@@ -1,0 +1,18 @@
+package com.server.oceankeeper.Global.Exception;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class DtoValidationException extends IllegalArgumentException{
+
+    private Map<String, String> errorMap;
+
+    public DtoValidationException(String message, Map<String, String> errorMap) {
+        super(message);
+        this.errorMap = errorMap;
+    }
+
+
+}

--- a/src/main/java/com/server/oceankeeper/Global/Handler/CustomExceptionHandler.java
+++ b/src/main/java/com/server/oceankeeper/Global/Handler/CustomExceptionHandler.java
@@ -2,6 +2,7 @@ package com.server.oceankeeper.Global.Handler;
 
 import com.amazonaws.Response;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.server.oceankeeper.Global.Exception.DtoValidationException;
 import com.server.oceankeeper.Global.Exception.DuplicatedResourceException;
 import com.server.oceankeeper.Global.Exception.IdNotFoundException;
 import com.server.oceankeeper.Global.Exception.IllegalRequestException;
@@ -32,7 +33,7 @@ public class CustomExceptionHandler {
     @ExceptionHandler(IdNotFoundException.class)
     public ResponseEntity<String> idNotFoundException(IdNotFoundException e){
         log.error(e.getMessage());
-        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(DuplicatedResourceException.class)
@@ -44,6 +45,12 @@ public class CustomExceptionHandler {
     @ExceptionHandler(AmazonS3Exception.class)
     public ResponseEntity<String> S3ArgumentException(AmazonS3Exception e){
         log.error(e.getMessage());
-        return new ResponseEntity<>(e.getMessage(), HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(DtoValidationException.class)
+    public ResponseEntity<String> validationApiException(DtoValidationException e){
+
+        return new ResponseEntity<>(e.getMessage()+": "+e.getErrorMap().toString(),HttpStatus.BAD_REQUEST);
     }
 }


### PR DESCRIPTION
- 모든 요청 dto에 notEmpty 애너테이션을 적용
- 회원가입요청 dto에 정규표현식 적용함 
  - 닉네임 : 한글/영문/숫자로만 구성된 2~20자 이내의 닉네임 
  - 이메일 : (한글/영문/숫자의 2~10자 내외) @ (영어/숫자 도메인 2~6자 내외) . (영문 2~3자 내외) 
                  [a-zA-Z0-9]{2,10}@[a-zA-Z0-9]{2,6}\\.[a-zA-Z]{2,3}$
